### PR TITLE
Use mpy map and heap where possible, use root pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ Consequently when running the [python test code](tests/py) using the standard Mi
 
 Just to get an idea here is a short sample of C++ code registration; code achieving the same using just the MicroPython API is not shown here but would likely be around 50 lines:
 
+The micropython-wrap type table needs to be registered as root pointer. Safe this as a `.c` file and add it to micropythons
+`MICROPY_SOURCE_QSTR` sources in cmake or `SRC_QSTR` in make. This is to make sure it is added to the global states root pointers
+and thus not collected by micropythons garbage-collector.
+
+```c
+#include "py/obj.h"
+
+//micropythons type table needs to be registered as root pointer to avoid garbage collection
+//the user needs to do this at least once to be able to compile micropython-wrap
+MP_REGISTER_ROOT_POINTER(mp_map_t* micropython_wrap_types_map_table);
+```
+
 ```c++
 #include <micropython-wrap/functionwrapper.h>
 

--- a/detail/functioncall.h
+++ b/detail/functioncall.h
@@ -198,6 +198,13 @@ namespace upywrap
 
     //Optional/keyword arguments.
     Arguments arguments;
+
+    /**
+     * @brief micropython-wrap allocates these objects using new. We want them on the micropython-heap
+     */
+    static void* operator new(size_t size) {
+      return m_malloc(size);
+    }
   };
 
   //Normal member function call
@@ -264,6 +271,13 @@ namespace upywrap
 
     //Optional/keyword arguments.
     Arguments arguments;
+
+    /**
+     * @brief micropython-wrap allocates these objects using new. We want them on the micropython-heap
+     */
+    static void* operator new(size_t size) {
+      return m_malloc(size);
+    }
   };
 }
 

--- a/detail/index.h
+++ b/detail/index.h
@@ -1,7 +1,7 @@
 #ifndef MICROPYTHON_WRAP_DETAIL_INDEX_H
 #define MICROPYTHON_WRAP_DETAIL_INDEX_H
 
-#include <map>
+#include "detail/mpmap.h"
 
 namespace upywrap
 {
@@ -17,7 +17,7 @@ namespace upywrap
   #define func_name_def( n ) static const char* n(){ return #n; }
 
   //Map type used to store functions
-  typedef std::map< void*, void* > function_ptrs;
+  typedef MPyMapView<void*, void*> function_ptrs;
 }
 
 #endif //#ifndef MICROPYTHON_WRAP_DETAIL_INDEX_H

--- a/detail/mpmap.h
+++ b/detail/mpmap.h
@@ -1,0 +1,100 @@
+#pragma once
+
+#include "micropythonc.h"
+#include <concepts>
+#include <optional>
+#include <type_traits>
+#include <utility>
+
+namespace upywrap {
+/**
+ * @brief A wrapper around the MicroPython map type.
+ *
+ * This class provides a convenient way to interact with the MicroPython map type.
+ * Objects of this type do not own the map, and are not responsible for its lifetime.
+ * The observer functions and Iterator are crafted specifically to support the micropython-wrap library
+ * with as little changes as possible. As such, `void *` is not treated as mp_obj_t, but rather as an integer type when used as key.
+ */
+template <class Key, class Value>
+requires std::is_pointer_v<Value>
+class MPyMapView {
+public:
+    using mapped_type = Value;
+    explicit MPyMapView(mp_map_t* map_ptr) : map_ { map_ptr } {}
+
+    Value& operator[](const qstr key) requires std::same_as<Key, qstr> {
+        mp_map_elem_t* elem = mp_map_lookup(map_, MP_OBJ_NEW_QSTR(key), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+        return reinterpret_cast<Value&>(elem->value);
+    }
+
+    bool contains(const qstr key) const requires std::same_as<Key, qstr> {
+        mp_map_elem_t* elem = mp_map_lookup(map_, MP_OBJ_NEW_QSTR(key), MP_MAP_LOOKUP);
+        return elem != nullptr;
+    }
+
+    /**
+     * @brief Converts a void pointer to an mp_obj_t.
+     * @warning While an mp_obj_t is technically a void*, this will rather convert the void* to an integer type.
+     */
+    mp_obj_t uint_obj_from_void_ptr(const void* ptr) const { 
+        auto key_uintptr = (uintptr_t)ptr;
+        auto key_mpuint = (mp_uint_t)key_uintptr;
+        mp_obj_t key_obj = mp_obj_new_int_from_uint(key_mpuint);
+        return key_obj;
+    }
+
+    /**
+     * @brief Access the map with a void pointer key. Micropytho-wrap uses this to use the name() functions (index_type) as keys.
+     * 
+     * We convert the void* here to an mp_uint_t, which is then used as the key in the micropython map.
+     */
+    Value& operator[](const void* key) requires std::same_as<Key, void*> {
+        mp_map_elem_t* elem = mp_map_lookup(map_, uint_obj_from_void_ptr(key), MP_MAP_LOOKUP_ADD_IF_NOT_FOUND);
+        return reinterpret_cast<Value&>(elem->value);
+    }
+
+    /**
+     * @brief Access the map with a void pointer key. Micropytho-wrap uses this to use the name() functions (index_type) as keys.
+     * 
+     * We convert the void* here to an mp_uint_t, which is then used as the key in the micropython map.
+     */
+    bool contains(const void* key) const requires std::same_as<Key, void*> {
+        mp_map_elem_t* elem = mp_map_lookup(map_, uint_obj_from_void_ptr(key), MP_MAP_LOOKUP);
+        return elem != nullptr;
+    }
+
+    /**
+     * @brief Minimal iterator for the MPyMapView.
+     *
+     * Micropython-wrap uses only find(), end() and ->, so we do not need to implement incrementing or dereferencing.
+     */
+    class FakeIterator {
+    public:
+        FakeIterator() = default;
+        FakeIterator(Key key, Value val) : val_{ { key, val } } {}
+
+        std::pair<Key, Value>* operator->() {
+            return &*val_;
+        }
+
+        bool operator==(const FakeIterator& other) const = default;
+
+    private:
+        std::optional<std::pair<Key, Value>> val_ {};
+    };
+
+    FakeIterator find(const Key& key) {
+        if (contains(key)) {
+            return FakeIterator {key, (*this)[key] };
+        }
+        return {};
+    }
+
+    FakeIterator end() {
+        return {};
+    }
+
+private:
+    mp_map_t* map_;
+};
+} // namespace upywrap

--- a/tests/cmodule.c
+++ b/tests/cmodule.c
@@ -4,3 +4,6 @@ extern void doinit_upywraptest(mp_obj_dict_t *);
 UPYWRAP_DEFINE_INIT_MODULE(upywraptest, doinit_upywraptest);
 MP_REGISTER_MODULE(MP_QSTR_upywraptest, upywraptest_module);
 MP_REGISTER_ROOT_POINTER(const mp_map_elem_t* upywraptest_module_globals_table);
+
+// Needs to be done once: Add global type map for micropython-wrap to the micropython state as root pointer
+MP_REGISTER_ROOT_POINTER(mp_map_t* micropython_wrap_types_map_table);

--- a/util.h
+++ b/util.h
@@ -109,9 +109,9 @@ namespace upywrap
     * Add an object to the given module's global dict.
     */
   template< class T >
-  void StoreGlobal( mp_obj_module_t* mod, const char* name, const T& obj )
+  void StoreGlobal( mp_obj_dict_t* mod, const char* name, const T& obj )
   {
-    mp_obj_dict_store( MP_OBJ_FROM_PTR( mod->globals ), new_qstr( name ), ToPy( obj ) );
+    mp_obj_dict_store( MP_OBJ_FROM_PTR( mod ), new_qstr( name ), ToPy( obj ) );
   }
 }
 


### PR DESCRIPTION
At this point this is more an RFC than a ready PR, as it changes a lot about how micropython-wrap works at the core. Please let me know if you're generally open for merging something like this, maybe behind a `#ifdef' or similar if you want to maintain the old behaviour as well.

My motivation is: We're using micropython-wrap since a while now on a freestanding C++ implementation on a microcontroller. We have no STL (vector, map) available. Also, apart from the micropython garbage collected heap no global heap for C/C++ allocations.

Therefore we replaced the map uses by maps stored on the micropython heap. This of course requires consideration for the garbage collector, as to not accidentally clean up the micropython-wrap generated bindings.

As a nice side effect, we need to neither store the `<class>_globals` nor the `_StaticPyObjectStore`  in a user-available location.

This replaces the use of std::map by micropython heap based maps. As a result, we need a root pointer for the root map such that the mpy garbage collector does not collect the micropython-wrap objects.

This root pointer needs to be declared once outside of micropython-wrap such that it is generated by the micropython generators.

All objects referenced by the map should also be on the micropython-heap. In this way, the garbage collector can properly track lifetimes.

This is the first step into allowing us to use micropython-wrap on mcus, and also allows us to reset the micropython-wrap state by resetting the global state map.