### PR TITLE
Introduce ClassHash to uniquely identify classwrappers, make -fno-rtti work

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -16,6 +16,10 @@ environment:
     - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
       MICROPY_CPYTHON3: python3
       FullTypeCheck: 1
+    - APPVEYOR_BUILD_WORKER_IMAGE: Ubuntu
+      MICROPY_CPYTHON3: python3
+      FullTypeCheck: 1
+      ExtraCppFlags: -fno-rtti
 
 configuration:
 - Debug
@@ -112,7 +116,7 @@ for:
 
   build_script:
   - ps: |
-      make test CC=gcc-9 CXX=g++-9 CPPFLAGS_EXTRA="-DUPYWRAP_FULLTYPECHECK=$env:FullTypeCheck"
+      make test CC=gcc-9 CXX=g++-9 CPPFLAGS_EXTRA="-DUPYWRAP_FULLTYPECHECK=$env:FullTypeCheck $env:ExtraCppFlags"
 
 on_failure:
 - ps: |

--- a/detail/configuration.h
+++ b/detail/configuration.h
@@ -103,21 +103,10 @@
 //Require exact type matches when converting uPy objects into native ones.
 //By default this is on in order to get proper error messages when passing mismatching types,
 //instead of possibly invoking undefined behavior by casting unrelated types.
-//However when your application wants to passs pointers to derived classes to functions
+//However when your application wants to pass pointers to derived classes to functions
 //taking base class pointers this has to be turned off.
-//Note: this requires C++ type information. For gcc (and possibly others) this means that it
-//doesn't work with -fno-rtti because that makes typeid() unavailable; which striclty speaking
-//shouldn't be because typeid() could work fine on types known at compile-time, as we use it.
-//Following that reasoning as well, msvc has no problems with it.
-//Not turned off automatically in case of !UPYWRAP_HAS_TYPEID because we want users to
-//be explicit about disabling this option.
 #ifndef UPYWRAP_FULLTYPECHECK
 #define UPYWRAP_FULLTYPECHECK (1)
-#endif
-#if defined( __cplusplus ) && !defined(NO_QSTR)
-#if UPYWRAP_FULLTYPECHECK && !UPYWRAP_HAS_TYPEID
-#error "UPYWRAP_FULLTYPECHECK requires RTTI. Build with -frtti or -DUPYWRAP_FULLTYPECHECK=0 (not advisable)"
-#endif
 #endif
 
 //Maximum number of keyword arguments a wrapped function call can support.

--- a/detail/util.h
+++ b/detail/util.h
@@ -125,6 +125,25 @@ namespace upywrap
   struct is_shared_ptr< std::shared_ptr< T > > : std::true_type
   {
   };
+
+  /**
+    * @brief Replacement for typeid without RTTI. This uniquely identifies the classwrapper type within an executable.
+    * @warning The hashes will change when recompiling or on other targets. Do not use cross-device or cross-executable.
+    *
+    * The functionality is based around the One Definition Rule (ODR), there must be exactly one definition of this function
+    * per class, even across translation units.
+    */
+  template< class T >
+  inline void* ClassHashImpl() {
+    static int static_hash_marker = 0;  // The address of this object is the unique hash of this classwrapper.
+    return &static_hash_marker;
+  }
+
+  template< class T >
+  inline void* ClassHash() {
+    // This assumes we do not make differences between differently qualified types.
+    return ClassHashImpl<typename std::remove_cv<typename std::remove_reference<T>::type>::type>();
+  }
 }
 
 #endif //#ifndef MICROPYTHON_WRAP_DETAIL_UTIL_H


### PR DESCRIPTION
Currently micropython-wrap depends on typeid (RTTI) to do a full type check, and for naming anonymous classwrappers.
This PR replaces the use of RTTI by a static object based hash for types to perform the full type check. Also anonymously wrapped types can optionally function without RTTI, by naming them `AnonymousClasswrapper`.

As a side note: I've also experimented with naming the anonymous wrapper via `__PRETTY_FUNCTION__`, but getting this to work reliably across all toolchains and versions is a bit of a mess. If you want, I can still implement this though.

I've also tried adding a CI test run for `-fno-rtti`, but I've not worked with appveyor yet, so lets see if this worked.